### PR TITLE
Add: Script to set Windows PowerPlan sleep settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ Generates a random strong password.
 #### IsPortOpen.ps1
 Determine if a port is open on a particular remote server.
 
-### UserLogons.vbs
+#### Set-WindowsSleepSettings.ps1
+Configures the sleep settings for the current power plan,
+defaults to sleeping after an hour idle on battery and never sleeping when plugged in.
+
+#### UserLogons.vbs
 Reports on who didn't log in today, across all domain controllers
 
 #### WhoShutItDown.ps1

--- a/Set-WindowsSleepSettings.ps1
+++ b/Set-WindowsSleepSettings.ps1
@@ -1,0 +1,32 @@
+param (
+    # Seconds to wait before sleeping the computer when running on battery.
+    #
+    # Defaults to 3600 seconds, or one hour.
+    [int] $DcTimeout = 3600,
+
+    # Seconds to wait before sleeping the computer while plugged in.
+    #
+    # Defaults to 0 which indicated that the computer should never sleep.
+    [int] $AcTimeOut = 0
+)
+
+# Get the current PowerPlan (e.g. Balanced or High Performance)
+$ActiveScheme = Invoke-Expression 'powercfg /getactivescheme'
+
+# Turn the output into something usable (RegEx magic)
+$RegEx = '(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}'
+$Guid = [regex]::Match($ActiveScheme,$RegEx).Value
+
+# ID for the category and setting we want to change
+# https://docs.microsoft.com/en-us/windows-hardware/customize/power-settings/configure-power-settings
+$SleepSettings = '238c9fa8-0aad-41ed-83f4-97be242c8f20'
+$IdleTimeout = '29f6c1db-86da-48c5-9fdb-f2b67b1f44da'
+
+# Change the "DC" setting, so while on battery. 3600 = Sleep after one hour idle
+Invoke-Expression "powercfg /setdcvalueindex $Guid $SleepSettings $IdleTimeout $DcTimeout"
+
+# Change the "AC" setting, so while on wall power. 0 = Never sleep
+Invoke-Expression "powercfg /setacvalueindex $Guid $SleepSettings $IdleTimeout $AcTimeOut"
+
+# Save the changes
+Invoke-Expression "powercfg /s $Guid"


### PR DESCRIPTION
This script was originally written to be run on PCs via InTune, but there is no reason this won't work locally or via and RMM tool.

It sets the sleep settings on for the current PowerPlan (e.g. Balanced, High Performance, etc.) both when the machine is on battery and plugged into external power.